### PR TITLE
make check_stanford task run every 2 hours

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -10,7 +10,7 @@ set :output, {:error => 'log/error.log', :standard => 'log/cron.log'}
 
 # Only set cron jobs in production
 
-every '15 * * * *', :roles => [:whenever] do
+every '15 */2 * * *', :roles => [:whenever] do
   rake 'layers:check_stanford'
 end
 


### PR DESCRIPTION
The check_stanford command is taking nearly an hour right now with ~1000 layers.